### PR TITLE
Fixing bug with empty lists not being registered as properties

### DIFF
--- a/hocon-property-example/pom.xml
+++ b/hocon-property-example/pom.xml
@@ -7,6 +7,10 @@
     <groupId>com.github.zeldigas</groupId>
     <artifactId>hocon-property-example</artifactId>
     <version>0.1-SNAPSHOT</version>
+    
+    <properties>
+        <spring-boot.version>2.2.8.RELEASE</spring-boot.version>
+    </properties>
 
     <build>
         <plugins>
@@ -29,25 +33,25 @@
         <dependency>
             <groupId>com.github.zeldigas</groupId>
             <artifactId>spring-hocon-property-source</artifactId>
-            <version>0.2.2</version>
+            <version>0.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>2.0.3.RELEASE</version>
+            <version>${spring-boot.version}</version>
         </dependency>
 
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>2.0.3.RELEASE</version>
+            <version>${spring-boot.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
-            <version>2.0.3.RELEASE</version>
+            <version>${spring-boot.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/hocon-property-example/src/test/java/com/github/zeldigas/example/hocon/AppTest.java
+++ b/hocon-property-example/src/test/java/com/github/zeldigas/example/hocon/AppTest.java
@@ -35,6 +35,6 @@ public class AppTest {
                 .block();
 
 
-        assertThat(result, sameJSONAs("{\"foo\":\"Hello\",\"bar\":42,\"aUri\":\"https://example.org/hello\",\"targetLocale\":\"en_US\",\"configuration\":{\"endpoints\":[\"one\",\"two\",\"three\"],\"connectionSettings\":{\"one\":\"hello\"}}}"));
+        assertThat(result, sameJSONAs("{\"foo\":\"Hello\",\"bar\":42,\"aUri\":\"https://example.org/hello\",\"targetLocale\":\"en-us\",\"configuration\":{\"endpoints\":[\"one\",\"two\",\"three\"],\"connectionSettings\":{\"one\":\"hello\"}}}"));
     }
 }

--- a/spring-hocon-property-source/pom.xml
+++ b/spring-hocon-property-source/pom.xml
@@ -46,8 +46,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spring-boot.version>2.2.8.RELEASE</spring-boot.version>
+        <hocon.version>1.4.0</hocon.version>
     </properties>
-
 
     <prerequisites>
         <maven>3.2.1</maven>
@@ -153,15 +154,14 @@
         <dependency>
             <groupId>com.typesafe</groupId>
             <artifactId>config</artifactId>
-            <version>1.3.3</version>
+            <version>${hocon.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot</artifactId>
-            <version>2.0.0.RELEASE</version>
+            <version>${spring-boot.version}</version>
             <scope>provided</scope>
         </dependency>
-
 
         <dependency>
             <groupId>junit</groupId>
@@ -178,7 +178,13 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.16</version>
+            <version>1.25</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>${spring-boot.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spring-hocon-property-source/src/main/java/com/github/zeldigas/spring/env/HoconPropertySource.java
+++ b/spring-hocon-property-source/src/main/java/com/github/zeldigas/spring/env/HoconPropertySource.java
@@ -1,0 +1,48 @@
+package com.github.zeldigas.spring.env;
+
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.core.annotation.AliasFor;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A utility meta annotation to allow for easier use of HOCON files as property sources;
+ * the annotation allows consumers to use @{@link HoconPropertySource} with .conf files in the same way
+ * they would use {@link PropertySource} with .properties files by extending the {@link PropertySource}
+ * annotation with the default factory class of {@link HoconPropertySourceFactory}.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@PropertySource(value = "", factory = HoconPropertySourceFactory.class)
+public @interface HoconPropertySource {
+
+    /**
+     * @see PropertySource#name()
+     */
+    @AliasFor(annotation = PropertySource.class)
+    String name() default "";
+
+    /**
+     * @see PropertySource#value()
+     */
+    @AliasFor(annotation = PropertySource.class)
+    String[] value();
+
+    /**
+     * @see PropertySource#ignoreResourceNotFound()
+     */
+    @AliasFor(annotation = PropertySource.class)
+    boolean ignoreResourceNotFound() default false;
+
+    /**
+     * @see PropertySource#encoding()
+     */
+    @AliasFor(annotation = PropertySource.class)
+    String encoding() default "";
+
+}

--- a/spring-hocon-property-source/src/main/java/com/github/zeldigas/spring/env/HoconPropertySourceFactory.java
+++ b/spring-hocon-property-source/src/main/java/com/github/zeldigas/spring/env/HoconPropertySourceFactory.java
@@ -1,0 +1,98 @@
+package com.github.zeldigas.spring.env;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigList;
+import com.typesafe.config.ConfigObject;
+import com.typesafe.config.ConfigParseOptions;
+import com.typesafe.config.ConfigSyntax;
+import com.typesafe.config.ConfigValue;
+import com.typesafe.config.ConfigValueFactory;
+import org.springframework.boot.env.OriginTrackedMapPropertySource;
+import org.springframework.boot.origin.Origin;
+import org.springframework.boot.origin.OriginTrackedValue;
+import org.springframework.boot.origin.TextResourceOrigin;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.EncodedResource;
+import org.springframework.core.io.support.PropertySourceFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * A {@link PropertySourceFactory} factory that loads a HOCON file into an instance of {@link PropertySource}.
+ */
+public class HoconPropertySourceFactory implements PropertySourceFactory {
+    private static final ConfigParseOptions PARSE_OPTIONS =
+            ConfigParseOptions.defaults().setSyntax(ConfigSyntax.CONF);
+
+    @Override
+    public PropertySource<?> createPropertySource(String name, EncodedResource encoded) throws IOException {
+        Resource resource = encoded.getResource();
+        String actualName = Optional.ofNullable(name).orElseGet(resource::getFilename);
+        Map<String, Object> source = toFlatMap(resource, parseHoconFrom(resource));
+        return new OriginTrackedMapPropertySource(actualName, source);
+    }
+
+    private Config parseHoconFrom(Resource resource) throws IOException {
+        try (InputStream inputStream = resource.getInputStream();
+             InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8)) {
+            return ConfigFactory.parseReader(reader, PARSE_OPTIONS).resolve();
+        }
+    }
+
+    private Map<String, Object> toFlatMap(Resource resource, Config config) {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        toFlatMap(properties, "", resource, config);
+        return properties;
+    }
+
+    private void toFlatMap(Map<String, Object> properties, String parentKey, Resource resource, Config config) {
+        final String prefix = "".equals(parentKey) ? "" : parentKey + ".";
+
+        for (Map.Entry<String, ConfigValue> entry : config.entrySet()) {
+            String propertyKey = prefix + entry.getKey();
+            addConfigValuePropertyTo(properties, propertyKey, resource, entry.getValue());
+        }
+    }
+
+    private void addConfigValuePropertyTo(Map<String, Object> properties, String key, Resource resource, ConfigValue value) {
+        if (value instanceof ConfigList) {
+            processListValue(properties, key, resource, (ConfigList) value);
+        } else if (value instanceof ConfigObject) {
+            processObjectValue(properties, key, resource, (ConfigObject) value);
+        } else {
+            processScalarValue(properties, key, resource, value);
+        }
+    }
+
+    private void processListValue(Map<String, Object> properties, String key, Resource resource, ConfigList value) {
+        if (value.isEmpty()) {
+            addConfigValuePropertyTo(properties, key, resource, ConfigValueFactory.fromAnyRef(""));
+        }
+
+        for (int i = 0; i < value.size(); i++) {
+            // Used to properly populate lists in @ConfigurationProperties beans
+            String propertyName = String.format("%s[%d]", key, i);
+            ConfigValue propertyValue = value.get(i);
+            addConfigValuePropertyTo(properties, propertyName, resource, propertyValue);
+        }
+    }
+
+    private void processObjectValue(Map<String, Object> properties, String key, Resource resource, ConfigObject value) {
+        toFlatMap(properties, key, resource, value.toConfig());
+    }
+
+    private void processScalarValue(Map<String, Object> properties, String key, Resource resource, ConfigValue value) {
+        properties.put(key, value.unwrapped());
+        Origin origin = new TextResourceOrigin(resource, new TextResourceOrigin.Location(value.origin().lineNumber() - 1, 0));
+        properties.put(key, OriginTrackedValue.of(value.unwrapped(), origin));
+    }
+
+}

--- a/spring-hocon-property-source/src/main/java/com/github/zeldigas/spring/env/HoconPropertySourceLoader.java
+++ b/spring-hocon-property-source/src/main/java/com/github/zeldigas/spring/env/HoconPropertySourceLoader.java
@@ -1,23 +1,14 @@
 package com.github.zeldigas.spring.env;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-
-import com.typesafe.config.*;
-import org.springframework.boot.env.OriginTrackedMapPropertySource;
 import org.springframework.boot.env.PropertySourceLoader;
-import org.springframework.boot.origin.Origin;
-import org.springframework.boot.origin.OriginTrackedValue;
-import org.springframework.boot.origin.TextResourceOrigin;
-import org.springframework.boot.origin.TextResourceOrigin.Location;
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.EncodedResource;
+import org.springframework.core.io.support.PropertySourceFactory;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Strategy to load '.conf' files in
@@ -26,8 +17,7 @@ import org.springframework.core.io.Resource;
  */
 public class HoconPropertySourceLoader implements PropertySourceLoader {
 
-    private static final ConfigParseOptions PARSE_OPTIONS =
-        ConfigParseOptions.defaults().setSyntax(ConfigSyntax.CONF);
+    private static final PropertySourceFactory HOCON_PROPERTY_SOURCE_LOADER = new HoconPropertySourceFactory();
 
     @Override
     public String[] getFileExtensions() {
@@ -36,61 +26,8 @@ public class HoconPropertySourceLoader implements PropertySourceLoader {
 
     @Override
     public List<PropertySource<?>> load(String name, Resource resource) throws IOException {
-        Map<String, Object> source = toFlatMap(resource, parseHoconFrom(resource));
-        return Collections.singletonList(
-            new OriginTrackedMapPropertySource(name, source)
-        );
-    }
-
-    private Config parseHoconFrom(Resource resource) throws IOException {
-        try (InputStream inputStream = resource.getInputStream();
-            InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8)) {
-            return ConfigFactory.parseReader(reader, PARSE_OPTIONS).resolve();
-        }
-    }
-
-    private Map<String, Object> toFlatMap(Resource resource, Config config) {
-        Map<String, Object> properties = new LinkedHashMap<>();
-        toFlatMap(properties, "", resource, config);
-        return properties;
-    }
-
-    private void toFlatMap(Map<String, Object> properties, String parentKey, Resource resource, Config config) {
-        final String prefix = "".equals(parentKey) ? "" : parentKey + ".";
-
-        for (Map.Entry<String, ConfigValue> entry : config.entrySet()) {
-            String propertyKey = prefix + entry.getKey();
-            addConfigValuePropertyTo(properties, propertyKey, resource, entry.getValue());
-        }
-    }
-
-    private void addConfigValuePropertyTo(Map<String, Object> properties, String key, Resource resource, ConfigValue value) {
-        if (value instanceof ConfigList) {
-            processListValue(properties, key, resource, (ConfigList) value);
-        } else if (value instanceof ConfigObject) {
-            processObjectValue(properties, key, resource, (ConfigObject) value);
-        } else {
-            processScalarValue(properties, key, resource, value);
-        }
-    }
-
-    private void processListValue(Map<String, Object> properties, String key,
-        final Resource resource, ConfigList value) {
-        for (int i = 0; i < value.size(); i++) {
-            // Used to properly populate lists in @ConfigurationProperties beans
-            String propertyName = String.format("%s[%d]", key, i);
-            ConfigValue propertyValue = value.get(i);
-            addConfigValuePropertyTo(properties, propertyName, resource, propertyValue);
-        }
-    }
-
-    private void processObjectValue(Map<String, Object> properties, String key, Resource resource, ConfigObject value) {
-        toFlatMap(properties, key, resource, value.toConfig());
-    }
-
-    private void processScalarValue(Map<String, Object> properties, String key, Resource resource, ConfigValue value) {
-        properties.put(key, value.unwrapped());
-        Origin origin = new TextResourceOrigin(resource, new Location(value.origin().lineNumber() - 1, 0));
-        properties.put(key, OriginTrackedValue.of(value.unwrapped(), origin));
+        EncodedResource encodedResource = new EncodedResource(resource);
+        PropertySource<?> propertySource = HOCON_PROPERTY_SOURCE_LOADER.createPropertySource(name, encodedResource);
+        return Collections.singletonList(propertySource);
     }
 }

--- a/spring-hocon-property-source/src/test/java/com/github/zeldigas/spring/env/FullApplicationTest.java
+++ b/spring-hocon-property-source/src/test/java/com/github/zeldigas/spring/env/FullApplicationTest.java
@@ -1,0 +1,36 @@
+package com.github.zeldigas.spring.env;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest("myApp.configuration.endpoints=[]")
+public class FullApplicationTest {
+
+    @Autowired
+    private Environment environment;
+
+    @Test
+    public void hoconPropertySourceAnnotationWorks() {
+        assertThat(environment.getProperty("my.hocon.property"), is("foo"));
+    }
+
+    @Test
+    public void emptyLists() {
+        assertThat(environment.getProperty("empty.list"), is(""));
+    }
+
+    @HoconPropertySource("classpath:hocon.conf")
+    @SpringBootApplication
+    static class TestSpringApplication {
+
+    }
+}

--- a/spring-hocon-property-source/src/test/resources/application.conf
+++ b/spring-hocon-property-source/src/test/resources/application.conf
@@ -21,3 +21,5 @@ myApp {
     }
   }
 }
+
+empty.list = []

--- a/spring-hocon-property-source/src/test/resources/application.yaml
+++ b/spring-hocon-property-source/src/test/resources/application.yaml
@@ -21,3 +21,5 @@ myApp:
       one: "hello"
       two:
         two_sub: "world!"
+
+empty.list: []

--- a/spring-hocon-property-source/src/test/resources/hocon.conf
+++ b/spring-hocon-property-source/src/test/resources/hocon.conf
@@ -1,0 +1,2 @@
+my.hocon.property = foo
+empty.list = [one, two, three]


### PR DESCRIPTION
Fixing bug with empty lists not being registered as properties
Introduced `@HoconPropertySources` helper annotation
Upgraded to Spring Boot 2.2
Updated tests and added new ones